### PR TITLE
Fix for #6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.1.4'
+version = '1.1.5'
 group = 'BananaFructa.tfcfarming' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'tfcfarming'
 

--- a/src/main/java/BananaFructa/tfcfarming/CropNutrients.java
+++ b/src/main/java/BananaFructa/tfcfarming/CropNutrients.java
@@ -97,7 +97,7 @@ public enum CropNutrients {
 
         } else {
             this.stepCost = 0;
-            this.favouriteNutrient = null;
+            this.favouriteNutrient = PHOSPHORUS; //safer default! Avoids NPE issue with TECropBaseN.processFactor
             this.crop = null;
         }
 

--- a/src/main/java/BananaFructa/tfcfarming/TECropBaseN.java
+++ b/src/main/java/BananaFructa/tfcfarming/TECropBaseN.java
@@ -32,7 +32,6 @@ public class TECropBaseN extends TECropBase {
     }
 
     public static double processFactor(NutrientValues nutrientValues, CropNutrients n) {
-        if (nutrientValues.getNPKSet() == null) return 0.3;
         return (nutrientValues.getNPKSet()[n.favouriteNutrient.ordinal()] >= n.stepCost ? 1 : 0.3);
     }
 

--- a/src/main/java/BananaFructa/tfcfarming/TECropBaseN.java
+++ b/src/main/java/BananaFructa/tfcfarming/TECropBaseN.java
@@ -32,6 +32,7 @@ public class TECropBaseN extends TECropBase {
     }
 
     public static double processFactor(NutrientValues nutrientValues, CropNutrients n) {
+        if (nutrientValues.getNPKSet() == null) return 0.3;
         return (nutrientValues.getNPKSet()[n.favouriteNutrient.ordinal()] >= n.stepCost ? 1 : 0.3);
     }
 

--- a/src/main/java/BananaFructa/tfcfarming/TFCFarming.java
+++ b/src/main/java/BananaFructa/tfcfarming/TFCFarming.java
@@ -30,7 +30,7 @@ public class TFCFarming {
 
     public static final String modId = "tfcfarming";
     public static final String name = "TFC Farming";
-    public static final String version = "1.1.4";
+    public static final String version = "1.1.5";
 
     public static TFCFarming INSTANCE;
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "tfcfarming",
   "name": "TFC Farming",
   "description": "TFC addon which implements soil nutrition mechanics.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",


### PR DESCRIPTION
Fixed the NPE as according to issue #6 where `favouriteNutrient` defaulted to null sometimes upon crop placement/update, it falls back to `PHOSPHORUS` to avoid the NPE.

You may make a 4th `FAULTTOLERANCE` enum entry in NutrientClass instead of using `PHOSPHORUS`, just make sure `this.favouriteNutrient` never defaults to or gives `null`, as that causes crashes.

Reminder: NPEs are especially fatal on Linux for some reason, which causes problems for servers.